### PR TITLE
Fixed issue with the progress bar; some code cleanup

### DIFF
--- a/CBRE.Editor/Compiling/ExportForm.Designer.cs
+++ b/CBRE.Editor/Compiling/ExportForm.Designer.cs
@@ -179,6 +179,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ProgressBar.Enabled = false;
             this.ProgressBar.Location = new System.Drawing.Point(20, 382);
+            this.ProgressBar.Maximum = 10000;
             this.ProgressBar.Name = "ProgressBar";
             this.ProgressBar.Size = new System.Drawing.Size(654, 23);
             this.ProgressBar.TabIndex = 14;

--- a/CBRE.Editor/Compiling/ExportForm.cs
+++ b/CBRE.Editor/Compiling/ExportForm.cs
@@ -230,25 +230,13 @@ namespace CBRE.Editor.Compiling
                     {
                         RMeshExport.SaveToFile(SaveFileName, Document, this);
                     }
-                    else if (extension.Equals(".fbx", StringComparison.InvariantCultureIgnoreCase))
+                    else if (extension.Equals(".fbx", StringComparison.InvariantCultureIgnoreCase) ||
+                        extension.Equals(".obj", StringComparison.InvariantCultureIgnoreCase) ||
+                        extension.Equals(".dae", StringComparison.InvariantCultureIgnoreCase) ||
+                        extension.Equals(".stl", StringComparison.InvariantCultureIgnoreCase) ||
+                        extension.Equals(".ply", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        GenericExport.SaveToFile(SaveFileName, Document, this, "fbx");
-                    }
-                    else if (extension.Equals(".obj", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        GenericExport.SaveToFile(SaveFileName, Document, this, "obj");
-                    }
-                    else if (extension.Equals(".dae", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        GenericExport.SaveToFile(SaveFileName, Document, this, "dae");
-                    }
-                    else if (extension.Equals(".stl", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        GenericExport.SaveToFile(SaveFileName, Document, this, "stl");
-                    }
-                    else if (extension.Equals(".ply", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        GenericExport.SaveToFile(SaveFileName, Document, this, "ply");
+                        GenericExport.SaveToFile(SaveFileName, Document, this, extension.Substring(1));
                     }
                     else
                     {

--- a/CBRE.Editor/Compiling/Lightmap/Lightmapper.cs
+++ b/CBRE.Editor/Compiling/Lightmap/Lightmapper.cs
@@ -142,7 +142,6 @@ namespace CBRE.Editor.Compiling.Lightmap
 
         public static void Render(Document document, ExportForm exportForm, out List<LMFace> faces, out int lmCount)
         {
-            exportForm.ProgressBar.Invoke((MethodInvoker)(() => exportForm.ProgressBar.Maximum = 10000));
             var textureCollection = document.TextureCollection;
 
             var map = document.Map;

--- a/CBRE.Providers/Model/AssimpProvider.cs
+++ b/CBRE.Providers/Model/AssimpProvider.cs
@@ -153,7 +153,6 @@ namespace CBRE.Providers.Model
 
         public static void SaveToFile(string filename,DataStructures.MapObjects.Map map,string format)
         {
-            AssimpContext exporter = new AssimpContext();
             Scene scene = new Scene();
 
             Node rootNode = new Node();
@@ -221,8 +220,7 @@ namespace CBRE.Providers.Model
                 rootNode.Children.Add(node);
             }
 
-
-            exporter.ExportFile(scene, filename, format);
+            new AssimpContext().ExportFile(scene, filename, format);
         }
     }
 }


### PR DESCRIPTION
When using a generic exporter (which don't invoke the lightmapper) before a rmesh exporter the value of the progress bar would be set above the max value, resulting in an error. This is also the more proper solution to setting the max value.