### PR TITLE
Fixed visgroups being untoggelable if they have no members

### DIFF
--- a/CBRE.Editor/UI/Sidebar/VisgroupSidebarPanel.cs
+++ b/CBRE.Editor/UI/Sidebar/VisgroupSidebarPanel.cs
@@ -59,14 +59,18 @@ namespace CBRE.Editor.UI.Sidebar
 
         private void SetCheckState(int visgroupId, ICollection<MapObject> visItems)
         {
-            var numHidden = visItems.Count(x => x.IsVisgroupHidden);
+            if (visItems.Count > 0) // Only override default checkbox behavior if necessary
+            {
+                var numHidden = visItems.Count(x => x.IsVisgroupHidden);
 
-            CheckState state;
-            if (numHidden == visItems.Count) state = CheckState.Unchecked; // All hidden
-            else if (numHidden > 0) state = CheckState.Indeterminate; // Some hidden
-            else state = CheckState.Checked; // None hidden
-
-            VisgroupPanel.SetCheckState(visgroupId, state);
+                CheckState state;
+                if (numHidden == visItems.Count && numHidden != 0) state = CheckState.Unchecked; // All hidden
+                else if (numHidden > 0) state = CheckState.Indeterminate; // Some hidden
+                else state = CheckState.Checked; // None hidden
+                VisgroupPanel.SetCheckState(visgroupId, state);
+            } else {
+                VisgroupPanel.SetCheckState(visgroupId, CheckState.Indeterminate);
+            }
         }
 
         private static List<MapObject> GetVisgroupItems(int visgroupId, Document doc)


### PR DESCRIPTION
This still doesn't fix the tree structure being broken though, probably unnecessary to fix atm considering switch from WinForms in th near future